### PR TITLE
upgrade Windows SDK version from 10.0.10502.0 to 10.0.10586.0

### DIFF
--- a/SpatialMapping/PlaneFinding/PlaneFinding/PlaneFinding.Editor/PlaneFinding.Editor.vcxproj
+++ b/SpatialMapping/PlaneFinding/PlaneFinding/PlaneFinding.Editor/PlaneFinding.Editor.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C656849B-7572-451D-BF74-73F78FE50D37}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PlaneFindingEditor</RootNamespace>
-    <TargetPlatformVersion>10.0.10502.0</TargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Addresses #7 

I am also changing the tag from TargetPlatformVersion to WindowsTargetPlatformVersion. I'm not sure of the difference, but in Visual Studio when I used the "Retarget solution" command it added a WindowsTargetPlatformVersion tag, but that didn't work while there was still an older TargetPlatformVersion tag. Other projects don't seem to use the TargetPlatformVersion tag, so hopefully WindowsTargetPlatformVersion is the correct tag to use. Please let me know if this seems incorrect.