### PR TITLE
Avoid passing FILE* across DLL boundary

### DIFF
--- a/SpatialUnderstanding/Src/Dll_Interface/Dll_Debug.cpp
+++ b/SpatialUnderstanding/Src/Dll_Interface/Dll_Debug.cpp
@@ -152,7 +152,7 @@ void DebugData_Save_DynamicScan_InitScan(
 	// Done
 	fclose(f);
 }
-EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan_InitScan(FILE* f)
+int DebugData_LoadAndSet_DynamicScan_InitScan(FILE* f)
 {
 	// Version
 	int version = 0; fread(&version, sizeof(int), 1, f);
@@ -200,7 +200,7 @@ void DebugData_Save_DynamicScan_UpdateScan(
 	// Done
 	fclose(f);
 }
-EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan_UpdateScan(FILE* f)
+int DebugData_LoadAndSet_DynamicScan_UpdateScan(FILE* f)
 {
 	// Data
 	Vec3f camPos, camFwd, camUp;
@@ -223,6 +223,29 @@ EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan_UpdateScan(F
 		camFwd.x, camFwd.y, camFwd.z,
 		camUp.x, camUp.y, camUp.z,
 		deltaTime);
+
+	return 1;
+}
+EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan(const char* filePath)
+{
+	FILE* f = NULL;
+	fopen_s(&f, filePath, "rb");
+	if (f == NULL)
+	{
+		return 0;
+	}
+
+	// Init
+	if (!DebugData_LoadAndSet_DynamicScan_InitScan(f))
+	{
+		return 0;
+	}
+
+	// Dynamic updates
+	while (DebugData_LoadAndSet_DynamicScan_UpdateScan(f))
+	{
+		Sleep((DWORD)(1000.0f / 60.0f));
+	}
 
 	return 1;
 }

--- a/SpatialUnderstanding/Src/TestApp/MainPage.xaml.cpp
+++ b/SpatialUnderstanding/Src/TestApp/MainPage.xaml.cpp
@@ -35,8 +35,7 @@ EXTERN_C __declspec(dllexport) void SpatialUnderstanding_Term();
 
 EXTERN_C __declspec(dllexport) void SetModeFrame_Inside();
 EXTERN_C __declspec(dllexport) bool DebugData_StaticMesh_LoadAndSet(const char* filePath, bool reCenterMesh);
-EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan_InitScan(FILE* f);
-EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan_UpdateScan(FILE* f);
+EXTERN_C __declspec(dllexport) int DebugData_LoadAndSet_DynamicScan(const char* filePath);
 EXTERN_C __declspec(dllexport) void DebugData_GeneratePlayspace_OneTimeScan();
 
 EXTERN_C __declspec(dllexport) void GeneratePlayspace_InitScan(
@@ -216,15 +215,9 @@ void TestApp::MainPage::RunTest_RealTimeScan_DynamicInputData()
 	}
 
 	// Init
-	if (!DebugData_LoadAndSet_DynamicScan_InitScan(f))
+	if (!DebugData_LoadAndSet_DynamicScan(fileName))
 	{
 		return;
-	}
-
-	// Dynamic updates
-	while (DebugData_LoadAndSet_DynamicScan_UpdateScan(f))
-	{
-		Sleep((DWORD)(1000.0f / 60.0f));
 	}
 
 	// Pull out the mesh


### PR DESCRIPTION
TestApp was opening a file and then passing the FILE* to SpatialUnderstanding. According to https://msdn.microsoft.com/en-us/library/ms235460.aspx, this can result in errors because the DLL may have differing CRT state. This *seems* like it explains the issue that I was seeing (#88).

To fix this, I am passing the desired filename to a new exported SpatialUnderstanding function that runs both the Init and the Update portions of the test. And I am removing export of the previous Init and Update functions that pass a FILE*.