### PR TITLE
embed dynMeshTest_0.out test file in TestApp project

### DIFF
--- a/SpatialUnderstanding/Src/TestApp/MainPage.xaml.cpp
+++ b/SpatialUnderstanding/Src/TestApp/MainPage.xaml.cpp
@@ -86,13 +86,14 @@ void TestApp::MainPage::Button_Click(Platform::Object^ sender, Windows::UI::Xaml
 #define INPUT_MESH "\\largeSR.out"
 #define DYNMESHTEST "\\dynMeshTest_0.out"
 
-// Note: To run these tests, copy the test data file listed above to your app's localstate folder
-// example: "C:\Users\<username>\AppData\Local\Packages\TestApp_c74ckhh66gw46\LocalState"
-
 const char* TestApp::MainPage::CalcInputMeshFilename()
 {
+	// NOTE: The INPUT_MESH file largeSR.out doesn't seem to be included in this repository.
+	// This file would need to be found/created and added to TestData content in the solution
+	// before this test could be used.
+
 	// Data file path
-	Windows::Storage::StorageFolder^ localFolder = Windows::Storage::ApplicationData::Current->LocalFolder;
+	Windows::Storage::StorageFolder^ localFolder = Windows::ApplicationModel::Package::Current->InstalledLocation;
 	Platform::String^ dir = localFolder->Path;
 	Platform::String^ fullPath = dir + INPUT_MESH;
 
@@ -107,8 +108,8 @@ const char* TestApp::MainPage::CalcInputMeshFilename()
 const char* TestApp::MainPage::CalcInputDynMeshTestFilename()
 {
 	// Data file path
-	Windows::Storage::StorageFolder^ localFolder = Windows::Storage::ApplicationData::Current->LocalFolder;
-	Platform::String^ dir = localFolder->Path;
+	Windows::Storage::StorageFolder^ appFolder = Windows::ApplicationModel::Package::Current->InstalledLocation;
+	Platform::String^ dir = appFolder->Path;
 	Platform::String^ fullPath = dir + DYNMESHTEST;
 
 	// some ugly code to get the LocalState folder into a simple char array:

--- a/SpatialUnderstanding/Src/TestApp/TestApp.vcxproj
+++ b/SpatialUnderstanding/Src/TestApp/TestApp.vcxproj
@@ -120,6 +120,9 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+    <None Include="..\bin\dynMeshTest_0.out">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="TestApp_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>

--- a/SpatialUnderstanding/Src/TestApp/TestApp.vcxproj.filters
+++ b/SpatialUnderstanding/Src/TestApp/TestApp.vcxproj.filters
@@ -8,6 +8,9 @@
       <UniqueIdentifier>1144aeee-6967-4a77-b7b2-9ce5e68e4cf7</UniqueIdentifier>
       <Extensions>bmp;fbx;gif;jpg;jpeg;tga;tiff;tif;png</Extensions>
     </Filter>
+    <Filter Include="TestData">
+      <UniqueIdentifier>{7993a602-604f-4027-aca1-2da11b1e5375}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
@@ -50,6 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="TestApp_TemporaryKey.pfx" />
+    <None Include="..\bin\dynMeshTest_0.out">
+      <Filter>TestData</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Page Include="MainPage.xaml" />


### PR DESCRIPTION
Previously, it was necessary to manually copy this file into the appropriate place before running a test. Now, the file is included in the solution so that it will automatically be deployed with TestApp.

This fixes #90.