### PR TITLE
Batch files for building and copying binaries to HoloToolkit-Unity

### DIFF
--- a/SpatialUnderstanding/Build.bat
+++ b/SpatialUnderstanding/Build.bat
@@ -1,0 +1,30 @@
+@echo off
+
+REM vsvars32.bat appears to have issues if you call it too many times from one command prompt.
+REM We'll use "DevEnvDir" to determine if we already ran it or if we need to run it again.
+@if "%DevEnvDir%"=="" call "%VS140COMNTOOLS%vsvars32.bat"
+
+call MSBuild Src\SpatialUnderstanding.sln /p:Configuration=StandaloneRelease;Platform=x86 /m %*
+IF NOT %ERRORLEVEL% == 0 goto BuildError
+
+call MSBuild Src\SpatialUnderstanding.sln /p:Configuration=StandaloneRelease;Platform=x64 /m %*
+IF NOT %ERRORLEVEL% == 0 goto BuildError
+
+call MSBuild Src\SpatialUnderstanding.sln /p:Configuration=UniversalRelease;Platform=x86 /m %*
+IF NOT %ERRORLEVEL% == 0 goto BuildError
+
+call MSBuild Src\SpatialUnderstanding.sln /p:Configuration=UniversalRelease;Platform=x64 /m %*
+IF NOT %ERRORLEVEL% == 0 goto BuildError
+
+:End
+echo ***********************************
+echo ********* Build Succeeded *********
+echo ***********************************
+exit /b 0
+
+:BuildError
+echo ***********************************
+echo ********** Build Failed ***********
+echo ***********************************
+pause
+exit /b 1

--- a/SpatialUnderstanding/CopyToUnity.bat
+++ b/SpatialUnderstanding/CopyToUnity.bat
@@ -1,0 +1,25 @@
+@echo off
+@setlocal
+
+if not exist "%HoloToolkitUnityRoot%" set HoloToolkitUnityRoot=%1
+if "x%HoloToolkitUnityRoot%" == "x" goto ErrorNoHoloToolkitUnityTarget
+if not exist "%HoloToolkitUnityRoot%\Assets" goto ErrorHoloToolkitUnityTargetInvalid
+
+xcopy Src\BuildOutput\bin\StandaloneRelease\Win32\SpatialUnderstanding\SpatialUnderstanding.dll "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\x86\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\StandaloneRelease\Win32\SpatialUnderstanding\SpatialUnderstanding.pdb "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\x86\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\StandaloneRelease\x64\SpatialUnderstanding\SpatialUnderstanding.dll "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\x64\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\StandaloneRelease\x64\SpatialUnderstanding\SpatialUnderstanding.pdb "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\x64\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\UniversalRelease\Win32\SpatialUnderstanding\SpatialUnderstanding\SpatialUnderstanding.dll "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\WSA\x86\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\UniversalRelease\Win32\SpatialUnderstanding\SpatialUnderstanding\SpatialUnderstanding.pdb "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\WSA\x86\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\UniversalRelease\x64\SpatialUnderstanding\SpatialUnderstanding\SpatialUnderstanding.dll "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\WSA\x64\" /S /I /F /H /R /K /Y
+xcopy Src\BuildOutput\bin\UniversalRelease\x64\SpatialUnderstanding\SpatialUnderstanding\SpatialUnderstanding.pdb "%HoloToolkitUnityRoot%\Assets\HoloToolkit\SpatialUnderstanding\Plugins\WSA\x64\" /S /I /F /H /R /K /Y
+
+exit /b 0
+
+:ErrorNoHoloToolkitUnityTarget
+echo Target path is required. Set the HoloToolkitUnityRoot environment variable or pass the root of the target Unity project as the first argument to this script.
+exit /b 1
+
+:ErrorHoloToolkitUnityTargetInvalid
+echo Target path is not a valid Unity project, verify that the Assets and External directories exists.
+exit /b 1


### PR DESCRIPTION
Fixes #99.
These batch files are modeled on the approach used in Sharing (BuildAll.bat, DeploySDKToUnity.bat).